### PR TITLE
Add forceRescan to the default environment

### DIFF
--- a/coreAPI/src/java/net/java/games/input/ControllerEnvironment.java
+++ b/coreAPI/src/java/net/java/games/input/ControllerEnvironment.java
@@ -103,6 +103,17 @@ public abstract class ControllerEnvironment {
      * or an empty array if there are no controllers in this environment.
      */
     public abstract Controller[] getControllers();
+    /**
+    * Force a re-scan of the hardware
+    * This is needed to detect new or missing hardware
+    * Use cases:
+    *  1) turning on bluetooth controllers after scanning and finding it missing
+    *  2) accessing newly pluged in USB devices
+    *  3) reconnecting hardware after battery failure 
+    * Returns a list of all controllers available to this environment,
+    * or an empty array if there are no controllers in this environment.
+    */
+    public Controller[] forceRescan();
     
     /**
      * Adds a listener for controller state change events.

--- a/coreAPI/src/java/net/java/games/input/ControllerEnvironment.java
+++ b/coreAPI/src/java/net/java/games/input/ControllerEnvironment.java
@@ -103,17 +103,6 @@ public abstract class ControllerEnvironment {
      * or an empty array if there are no controllers in this environment.
      */
     public abstract Controller[] getControllers();
-    /**
-    * Force a re-scan of the hardware
-    * This is needed to detect new or missing hardware
-    * Use cases:
-    *  1) turning on bluetooth controllers after scanning and finding it missing
-    *  2) accessing newly pluged in USB devices
-    *  3) reconnecting hardware after battery failure 
-    * Returns a list of all controllers available to this environment,
-    * or an empty array if there are no controllers in this environment.
-    */
-    public Controller[] forceRescan();
     
     /**
      * Adds a listener for controller state change events.

--- a/coreAPI/src/java/net/java/games/input/DefaultControllerEnvironment.java
+++ b/coreAPI/src/java/net/java/games/input/DefaultControllerEnvironment.java
@@ -114,7 +114,21 @@ class DefaultControllerEnvironment extends ControllerEnvironment {
      */
     public DefaultControllerEnvironment() {
     }
-    
+    /**
+    * Force a re-scan of the hardware
+    * This is needed to detect new or missing hardware
+    * Use cases:
+    *  1) turning on bluetooth controllers after scanning and finding it missing
+    *  2) accessing newly pluged in USB devices
+    *  3) reconnecting hardware after battery failure 
+    * Returns a list of all controllers available to this environment,
+    * or an empty array if there are no controllers in this environment.
+    */
+    public Controller[] forceRescan() {
+        loadedPlugins.clear();
+	controllers = null;
+	return getControllers();
+    }
     /**
      * Returns a list of all controllers available to this environment,
      * or an empty array if there are no controllers in this environment.


### PR DESCRIPTION
This method allows the application to rescan for changes in hardware.

In the normal use case an application would start up and either the controller is present or not. With this method you can scan for changes in hardware. No other functionality is affected. 